### PR TITLE
Fix character settings merge to preserve existing values

### DIFF
--- a/server/storage.ts
+++ b/server/storage.ts
@@ -100,7 +100,21 @@ export class MemStorage implements IStorage {
   }
 
   async updateCharacterSettings(settings: CharacterSettings): Promise<void> {
-    this.characterSettings = { ...this.characterSettings, ...settings };
+    for (const [characterId, updates] of Object.entries(settings)) {
+      const existingEntry = this.characterSettings[characterId];
+      const mergedCustomizations = {
+        ...(existingEntry?.customizations ?? {}),
+        ...(updates.customizations ?? {}),
+      };
+
+      this.characterSettings[characterId] = {
+        ...(existingEntry ?? {}),
+        ...updates,
+        ...(Object.keys(mergedCustomizations).length > 0
+          ? { customizations: mergedCustomizations }
+          : {}),
+      };
+    }
   }
 }
 


### PR DESCRIPTION
## Summary
- update in-memory character settings persistence to merge updates per character entry
- preserve existing configuration, including nested customization data, when updating character settings

## Testing
- `npm run check` *(fails: existing type errors in example components, unrelated to change)*

------
https://chatgpt.com/codex/tasks/task_e_68ce02fe2f408321b1bfc648d6c6f2e5